### PR TITLE
Stop inserting space in front of topic titles that aren't numbered

### DIFF
--- a/customization.xsl
+++ b/customization.xsl
@@ -59,11 +59,11 @@
                                 *[contains(@class, ' map/topicref ')]
                                 [not(ancestor-or-self::*[contains(@class, ' bookmap/frontmatter ')])]"
                                 format="1.1" level="multiple"/>
+                            <xsl:value-of select="' '"/>
                         </xsl:when>
                     </xsl:choose>
                 </xsl:for-each>
             </fo:inline>
-            <xsl:value-of select="' '"/>
         </xsl:if>
                 
         <xsl:apply-templates/>


### PR DESCRIPTION
Topic headers that weren't numbered were prepended with space character, which resulted in unwanted identation.